### PR TITLE
Add some safeguards for appserver dependency

### DIFF
--- a/modules/RtcWebrtcAdapter.js
+++ b/modules/RtcWebrtcAdapter.js
@@ -31,7 +31,7 @@ rtcAdapterInit();
 //  * @returns 
 //  * 
 // */
-// RtcWebrtcAdapter.getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
+RtcWebrtcAdapter.getUserMedia = ( typeof(navigator) !== 'undefined' ) ? navigator.webkitGetUserMedia.bind(navigator) : null;
 
 
 function rtcAdapterInit() {

--- a/modules/RtcWebrtcAdapter.js
+++ b/modules/RtcWebrtcAdapter.js
@@ -35,11 +35,12 @@ rtcAdapterInit();
 
 
 function rtcAdapterInit() {
-    if (RtcBrowserType.isChrome()) {
+    var navigator = ( typeof(navigator) !== 'undefined' ) ? navigator : null;
+    if (navigator && RtcBrowserType.isChrome()) {
         RtcWebrtcAdapter.RTCPeerConnection = webkitRTCPeerConnection;
         RtcWebrtcAdapter.RTCIceCandidate = RTCIceCandidate;
         RtcWebrtcAdapter.getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
-    } else if (RtcBrowserType.isFirefox()) {
+    } else if (navigator && RtcBrowserType.isFirefox()) {
         RtcWebrtcAdapter.RTCPeerConnection = mozRTCPeerConnection;
         RtcWebrtcAdapter.RTCIceCandidate = mozRTCIceCandidate;
         RtcWebrtcAdapter.getUserMedia = navigator.mozGetUserMedia.bind(navigator);

--- a/modules/RtcWebrtcAdapter.js
+++ b/modules/RtcWebrtcAdapter.js
@@ -15,7 +15,7 @@ rtcAdapterInit();
 //  * @returns 
 //  * 
 // */
-// RtcWebrtcAdapter.RTCPeerConnection = webkitRTCPeerConnection ;
+RtcWebrtcAdapter.RTCPeerConnection = webkitRTCPeerConnection ;
 
 // /** 
 //  * RTCIceCandidate definition
@@ -23,7 +23,7 @@ rtcAdapterInit();
 //  * @returns 
 //  * 
 // */
-// RtcWebrtcAdapter.RTCIceCandidate = RTCIceCandidate ;
+RtcWebrtcAdapter.RTCIceCandidate = RTCIceCandidate ;
 
 // /** 
 //  * getUserMedia definition

--- a/modules/Utils/RtcBrowserType.js
+++ b/modules/Utils/RtcBrowserType.js
@@ -3,6 +3,8 @@
 var currentBrowser;
 var browserVersion;
 
+var navigator = ( typeof(navigator) !== 'undefined' ) ? navigator : null;
+
 var RtcBrowserType = {
 
     RTC_BROWSER_CHROME: "chrome",
@@ -38,7 +40,7 @@ var RtcBrowserType = {
 }
 
 function detectChrome() {
-    if (navigator.webkitGetUserMedia) {
+    if (navigator && navigator.webkitGetUserMedia) {
         currentBrowser = RtcBrowserType.RTC_BROWSER_CHROME;
         var userAgent = navigator.userAgent.toLowerCase();
         // We can assume that user agent is chrome, because it's
@@ -51,17 +53,19 @@ function detectChrome() {
 }
 
 function detectOpera() {
-    var userAgent = navigator.userAgent;
-    if (userAgent.match(/Opera|OPR/)) {
-        currentBrowser = RtcBrowserType.RTC_BROWSER_OPERA;
-        var version = userAgent.match(/(Opera|OPR) ?\/?(\d+)\.?/)[2];
-        return version;
+    if (navigator) {
+        var userAgent = navigator.userAgent;
+        if (userAgent.match(/Opera|OPR/)) {
+            currentBrowser = RtcBrowserType.RTC_BROWSER_OPERA;
+            var version = userAgent.match(/(Opera|OPR) ?\/?(\d+)\.?/)[2];
+            return version;
+        }
+        return null;
     }
-    return null;
 }
 
 function detectFirefox() {
-    if (navigator.mozGetUserMedia) {
+    if (navigator && navigator.mozGetUserMedia) {
         currentBrowser = RtcBrowserType.RTC_BROWSER_FIREFOX;
         var version = parseInt(
             navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1], 10);

--- a/modules/node-xmpp-client/lib/websockets.js
+++ b/modules/node-xmpp-client/lib/websockets.js
@@ -10,7 +10,7 @@ var ws = require('ws')
 var logger = require('../../RtcLogger.js');
 
  // we ignore ws in the browser field of package.json
-var WebSocket = ws.Server ? ws : window.WebSocket
+var WebSocket = ws.Server ? ws : ( (typeof(window) !== 'undefined') ? window.WebSocket : null )
 
 var NS_FRAMING = 'urn:ietf:params:xml:ns:xmpp-framing'
 var NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iris-js-sdk",
-    "version": "3.3.0",
+    "version": "3.3.2",
     "description": "JavaScript SDK for Iris Rtc Platform",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iris-js-sdk",
-    "version": "3.3.2",
+    "version": "3.3.0",
     "description": "JavaScript SDK for Iris Rtc Platform",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Our Appserver has a dependency on the JS/React SDKs as well, and is getting errors while trying to start because of the undefined window/navigator object. This PR fixes that issue. 

- [x] Add null check around window object
- [x] Add null check around navigator object